### PR TITLE
Fix Safari compatibility for aurora animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,15 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@keyframes aurora {
+  from {
+    background-position: 50% 50%, 50% 50%;
+  }
+  to {
+    background-position: 350% 50%, 350% 50%;
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -148,14 +157,5 @@
   h5,
   h6 {
     @apply font-[family-name:var(--font-display)] font-bold;
-  }
-}
-
-@keyframes aurora {
-  from {
-    background-position: 50% 50%, 50% 50%;
-  }
-  to {
-    background-position: 350% 50%, 350% 50%;
   }
 }


### PR DESCRIPTION
## Summary

Fixes sidebar rendering issue in Safari by reordering CSS keyframes definition.

## Problem

Safari was not displaying the sidebar correctly due to the `@keyframes aurora` animation being defined after it was referenced in the `@theme inline` block. Safari is stricter about CSS ordering than Chrome and requires keyframes to be defined before they are referenced.

## Solution

Moved `@keyframes aurora` definition to appear before the `@theme inline` block, ensuring Safari can properly parse and apply the animation.

## Testing

- ✅ Works in Chrome (already working)
- 🧪 Needs testing in Safari after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)